### PR TITLE
Fix Android Kotlin plugin resolution

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,5 @@
-plugins {
-    id 'com.android.application'
-    id 'kotlin-android'
-}
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.example.ciceroocr'


### PR DESCRIPTION
## Summary
- use `apply plugin` statements in app module
- remove DSL `plugins` block causing plugin resolution failure

## Testing
- `./gradlew tasks --all` *(fails: Unable to access jarfile /workspace/CiceroOCR/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686def4c6a248327848c21a91819effd