### PR TITLE
Fix tess-two dependency group

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     implementation 'com.google.mlkit:text-recognition:16.0.0'
 
     // Tesseract tess-two
-    implementation 'org.jetbrains.tess-two:tess-two:9.1.0'
+    implementation 'com.rmtheis:tess-two:9.1.0'
 }


### PR DESCRIPTION
## Summary
- point tess-two dependency at the correct Maven coordinates

## Testing
- `gradle build --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df08513588327a12e9dfbcc14a568