### PR TITLE
Fix Android exported flags

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
 
-        <activity android:name=".camerax.CameraXMLKitActivity" />
-        <activity android:name=".tesseract.TesseractActivity" />
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".camerax.CameraXMLKitActivity"
+            android:exported="false" />
+        <activity
+            android:name=".tesseract.TesseractActivity"
+            android:exported="false" />
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- update AndroidManifest to declare exported state for all activities

## Testing
- `./gradlew test` *(fails: unsupported class file major version)*

------
https://chatgpt.com/codex/tasks/task_e_686df344f19483278a248754e7500062